### PR TITLE
Stop trying to close map_sides JSON handle.

### DIFF
--- a/scripting/get5/matchconfig.sp
+++ b/scripting/get5/matchconfig.sp
@@ -528,7 +528,6 @@ static bool LoadMatchFromJson(JSON_Object json) {
         array.GetString(keyAsString, buffer, sizeof(buffer));
         g_MapSides.Push(SideTypeFromString(buffer));
       }
-      CloseHandle(array);
     }
   }
 


### PR DESCRIPTION
The handles returned by GetObject are not deep copies, they're internal pointers, and should not be closed.